### PR TITLE
fix: allows decimal values in numerical input

### DIFF
--- a/src/forms/FormInput.jsx
+++ b/src/forms/FormInput.jsx
@@ -25,6 +25,10 @@ export function FormInput({ type, name, required: _required, disabled: _disabled
     attrs.value = getValue();
   }
 
+  if (type === 'number' && !_attrs.step) {
+    attrs.step = 'any';
+  }
+
   return <input {...attrs} className="form-control" onChange={handleOnChangeFactory(afterChange)} ref={registerRef} />;
 }
 


### PR DESCRIPTION
If an `input` has `type="number"` but none `step` property was provided, the `Form` validation may treat decimal values as invalid ones.

Found a solution [here](https://stackoverflow.com/questions/19011861/is-there-a-float-input-type-in-html5/19012837#19012837)