### PR TITLE
feat(autocomplete): new parameter to allow custom user input

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -176,6 +176,15 @@ export function FormExamples() {
             required={() => false}
           />
         </div>
+        <div className="col">
+          <FormGroupAutocomplete
+            name="autocompleteField4"
+            label="Autocomplete that allows custom user input"
+            options={['1234', '2345', '3456']}
+            placeholder="Type some numbers"
+            allowCustomInput={true}
+          />
+        </div>
       </div>
 
       <div className="row">

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -182,7 +182,7 @@ export function FormExamples() {
             label="Autocomplete that allows custom user input"
             options={['1234', '2345', '3456']}
             placeholder="Type some numbers"
-            allowCustomInput={true}
+            allowUnlistedValue={true}
           />
         </div>
       </div>

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -21,6 +21,7 @@ export function FormAutocomplete({
   filter,
   disabled: _disabled,
   afterChange,
+  allowCustomInput,
 }) {
   const { getValue, setValue: _setValue, register, isValid, getFormSubmitedAttempted, getFormData } = useFormControl(
     name
@@ -98,6 +99,8 @@ export function FormAutocomplete({
       setValue('');
       setSelectedItem(null);
       updateSearchInputValidation();
+    } else if (isEmptyLike(selectedItem) && !isEmptyLike(searchValue) && allowCustomInput) {
+      onSelectItem({ value: searchValue, label: searchValue });
     }
 
     if (ignoreBlur) {
@@ -106,7 +109,7 @@ export function FormAutocomplete({
       close();
       setFocus(false);
     }
-  }, [close, ignoreBlur, searchValue, setValue, updateSearchInputValidation, value]);
+  }, [close, ignoreBlur, searchValue, setValue, updateSearchInputValidation, value, onSelectItem]);
 
   const enableSearchInput = useCallback(() => {
     if (disabled) {

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -204,6 +204,7 @@ FormAutocomplete.defaultProps = {
 
 FormAutocomplete.propTypes = {
   afterChange: PropTypes.func,
+  allowCustomInput: PropTypes.bool,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   filter: PropTypes.func,
   id: PropTypes.string,
@@ -230,6 +231,7 @@ export function FormGroupAutocomplete(props) {
 
 FormGroupAutocomplete.propTypes = {
   afterChange: PropTypes.func,
+  allowCustomInput: PropTypes.bool,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   filter: PropTypes.func,
   help: PropTypes.node,

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -109,7 +109,7 @@ export function FormAutocomplete({
       close();
       setFocus(false);
     }
-  }, [close, ignoreBlur, searchValue, setValue, updateSearchInputValidation, value, onSelectItem]);
+  }, [close, ignoreBlur, searchValue, setValue, updateSearchInputValidation, value, onSelectItem, allowCustomInput]);
 
   const enableSearchInput = useCallback(() => {
     if (disabled) {

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -21,7 +21,7 @@ export function FormAutocomplete({
   filter,
   disabled: _disabled,
   afterChange,
-  allowCustomInput,
+  allowUnlistedValue,
 }) {
   const { getValue, setValue: _setValue, register, isValid, getFormSubmitedAttempted, getFormData } = useFormControl(
     name
@@ -99,7 +99,7 @@ export function FormAutocomplete({
       setValue('');
       setSelectedItem(null);
       updateSearchInputValidation();
-    } else if (isEmptyLike(selectedItem) && !isEmptyLike(searchValue) && allowCustomInput) {
+    } else if (isEmptyLike(selectedItem) && !isEmptyLike(searchValue) && allowUnlistedValue) {
       onSelectItem({ value: searchValue, label: searchValue });
     }
 
@@ -109,7 +109,17 @@ export function FormAutocomplete({
       close();
       setFocus(false);
     }
-  }, [close, ignoreBlur, searchValue, setValue, updateSearchInputValidation, value, onSelectItem, allowCustomInput]);
+  }, [
+    close,
+    ignoreBlur,
+    searchValue,
+    setValue,
+    updateSearchInputValidation,
+    value,
+    onSelectItem,
+    allowUnlistedValue,
+    selectedItem,
+  ]);
 
   const enableSearchInput = useCallback(() => {
     if (disabled) {
@@ -204,7 +214,7 @@ FormAutocomplete.defaultProps = {
 
 FormAutocomplete.propTypes = {
   afterChange: PropTypes.func,
-  allowCustomInput: PropTypes.bool,
+  allowUnlistedValue: PropTypes.bool,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   filter: PropTypes.func,
   id: PropTypes.string,
@@ -231,7 +241,7 @@ export function FormGroupAutocomplete(props) {
 
 FormGroupAutocomplete.propTypes = {
   afterChange: PropTypes.func,
-  allowCustomInput: PropTypes.bool,
+  allowUnlistedValue: PropTypes.bool,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   filter: PropTypes.func,
   help: PropTypes.node,


### PR DESCRIPTION
Creates a new parameter that allows the user to input data manually instead of having to always choose one of the options.

New entry to showcase the changes:
![autocompleteCustomInput](https://user-images.githubusercontent.com/56827865/100245953-5dd62280-2f17-11eb-8448-09271dbd132a.gif)
