### PR TITLE
feat: allow input masks functions on forminput2

### DIFF
--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -7,7 +7,13 @@ export function Form2Examples() {
     <div>
       Alternative Form implementation
       <Form2
-        initialValues={{ attrA: 'ABC', Obj: { x: 'X', z: 0 }, arr: [1, 2, 3], arrObj: [{ o: 1 }, { o: 2 }, { o: 3 }] }}
+        initialValues={{
+          attrA: 'ABC',
+          Obj: { x: 'X', z: 0 },
+          arr: [1, 2, 3],
+          arrObj: [{ o: 1 }, { o: 2 }, { o: 3 }],
+          masks: {},
+        }}
         onSubmit={(data) => console.log('onSubmit', data)}
         onChange={(data) => console.log('onChange', data)}
         transform={(formData) => {
@@ -76,6 +82,8 @@ export function Form2Examples() {
           <FormVersion />
         </div>
 
+        <FormMasked />
+
         <div className="form-group">
           <label htmlFor="">Observer</label>
           <FormObserver />
@@ -121,4 +129,96 @@ function FormObserver() {
   });
 
   return <div>{state}</div>;
+}
+
+function FormMasked() {
+  const percentageFormControl = useFormControl2('masks.percentageValue');
+
+  const decimalMask = function (v) {
+    let maskedValue = String(v);
+
+    maskedValue = maskedValue.replace(/\D/g, '');
+    maskedValue = maskedValue.replace(/(\d)(\d{3})$/, '$1.$2');
+
+    return maskedValue;
+  };
+
+  const dateMask = function (v) {
+    let maskedValue = v;
+
+    maskedValue = maskedValue.replace(/\D/g, '');
+
+    maskedValue = maskedValue.replace(/(\d{2})(\d)/, '$1/$2');
+    maskedValue = maskedValue.replace(/(\d{2})(\d)/, '$1/$2');
+
+    return maskedValue;
+  };
+
+  const hourMask = function (v) {
+    let maskedValue = v;
+
+    maskedValue = maskedValue.replace(/\D/g, '');
+    maskedValue = maskedValue.replace(/(\d{2})(\d)/, '$1:$2');
+
+    return maskedValue;
+  };
+
+  const currency = function (v) {
+    let maskedValue = v;
+
+    maskedValue = maskedValue.replace(/\D/g, '');
+    maskedValue = maskedValue.replace(/(\d)(\d{2})$/, '$1,$2');
+    maskedValue = maskedValue.replace(/(?=(\d{3})+(\D))\B/g, '.');
+
+    return maskedValue;
+  };
+
+  const percentageMask = function (v) {
+    let maskedValue = v;
+    maskedValue = maskedValue.replace(/[^0-9\.]/g, '');
+
+    if (!maskedValue) {
+      return '';
+    }
+
+    return `${maskedValue}%`;
+  };
+
+  return (
+    <div>
+      <strong>Masked Inputs</strong>
+      <div className="form-group">
+        <label htmlFor="">Masked Date</label>
+        <FormInput2 name="masks.date" maxLength="10" maskFunction={dateMask} />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="">Masked Hour</label>
+        <FormInput2 name="masks.hour" maxLength="5" maskFunction={hourMask} />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="">Masked 3 decimals Number</label>
+        <FormInput2 name="masks.decimal" maskFunction={decimalMask} />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="">Percentage Mask % </label>
+        <FormInput2
+          name="masks.percentage"
+          maskFunction={percentageMask}
+          afterChange={(value) => {
+            const rawValue = value.replace(/\%/, '');
+            percentageFormControl.setValue(Number(rawValue) / 100);
+          }}
+        />
+        <FormInput2 type="number" name="masks.percentageValue" style={{ display: 'none' }} />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="">currency</label>
+        <FormInput2 name="masks.currency" maskFunction={currency} />
+      </div>
+    </div>
+  );
 }

--- a/src/forms2/FormInput.jsx
+++ b/src/forms2/FormInput.jsx
@@ -5,7 +5,15 @@ import { booleanOrFunction } from '../forms/helpers/form-helpers';
 
 import { useFormControl2 } from './helpers/useFormControl';
 
-export function FormInput2({ type, name, required: _required, disabled: _disabled, afterChange, ..._attrs }) {
+export function FormInput2({
+  type,
+  name,
+  required: _required,
+  disabled: _disabled,
+  afterChange,
+  maskFunction,
+  ..._attrs
+}) {
   const { getValue, handleOnChangeFactory, getFormData } = useFormControl2(name);
 
   const disabled = booleanOrFunction(_disabled, getFormData());
@@ -25,7 +33,9 @@ export function FormInput2({ type, name, required: _required, disabled: _disable
     attrs.value = getValue();
   }
 
-  return <input {...attrs} className="form-control" onChange={handleOnChangeFactory(afterChange)} />;
+  return (
+    <input {...attrs} className="form-control" onChange={handleOnChangeFactory(afterChange, type, maskFunction)} />
+  );
 }
 
 FormInput2.defaultProps = {
@@ -36,6 +46,7 @@ FormInput2.propTypes = {
   afterChange: PropTypes.func,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   id: PropTypes.string,
+  maskFunction: PropTypes.func,
   max: PropTypes.string,
   maxLength: PropTypes.string,
   min: PropTypes.string,

--- a/src/forms2/helpers/useFormControl.jsx
+++ b/src/forms2/helpers/useFormControl.jsx
@@ -26,14 +26,20 @@ export function useFormControl2(name, type) {
   );
 
   const handleOnChange = useCallback(
-    ({ target }, _type) => {
+    ({ target }, _type, maskFunction) => {
       const value = getTargetValue(target);
 
-      const decodedValue = decode(value, type || _type);
+      let maskedOrDecodedValue;
 
-      setValue(decodedValue);
+      if (isFunction(maskFunction)) {
+        maskedOrDecodedValue = maskFunction(value);
+      } else {
+        maskedOrDecodedValue = decode(value, type || _type);
+      }
 
-      return decodedValue;
+      setValue(maskedOrDecodedValue);
+
+      return maskedOrDecodedValue;
     },
     [setValue, type]
   );
@@ -54,8 +60,8 @@ export function useFormControl2(name, type) {
     isRegistered() {
       return isRegistered;
     },
-    handleOnChangeFactory: (afterChange, type) => (e) => {
-      const newValue = handleOnChange(e, type);
+    handleOnChangeFactory: (afterChange, type, maskFunction) => (e) => {
+      const newValue = handleOnChange(e, type, maskFunction);
 
       if (isFunction(afterChange)) {
         afterChange(newValue);


### PR DESCRIPTION
The idea with this PR is to allow custom input masks. After studying possibilities I decided to pass a maskFunction in FormInput2 that is executed inside the setValue function, so that the result is automatically updated in FormContext state (my first approach was define a onKeyDown event that changed directly the target value in the input, but that resulted in outdated form values)

Result:
https://user-images.githubusercontent.com/29656850/122920101-6371da80-d337-11eb-9124-d1b91e29c057.mp4

